### PR TITLE
Fix bug where -startAnimating call does not trigger the _activityIndicator to show up.

### DIFF
--- a/BMYCircularProgressPullToRefresh/BMYPullToRefreshView/BMYPullToRefreshView.m
+++ b/BMYCircularProgressPullToRefresh/BMYPullToRefreshView/BMYPullToRefreshView.m
@@ -70,8 +70,9 @@ static CGFloat const kPullToRefreshDragToTrigger = 80;
     if (fequalzero(_scrollView.contentOffset.y)) {
         [_scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x, -CGRectGetHeight(self.frame)) animated:YES];
     }
-    
-    self.state = BMYPullToRefreshStateLoading;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      self.state = BMYPullToRefreshStateLoading;
+    });
 }
 
 - (void)stopAnimating {


### PR DESCRIPTION
Manually tested by adding the following code in the BMYViewController.m

<pre>
- (void)viewDidAppear:(BOOL)animated {
  [super viewDidAppear:animated];
  [self.tableViewWithContentInset1.pullToRefreshView startAnimating];
}
</pre>