### PR TITLE
Fix bug with tearDown method not disposing of pullToRefreshView

### DIFF
--- a/BMYCircularProgressPullToRefresh.podspec
+++ b/BMYCircularProgressPullToRefresh.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'BMYCircularProgressPullToRefresh'
-  s.version  = '1.1.1'
+  s.version  = '1.1.2'
   s.platform = :ios, '5.0'
   s.summary  = 'Pull to fresh with circular progress view as used in the Beamly iOS app.'
   s.description = 'This version of the pull to refresh feature can be used both on UITableViews and UICollectionViews. When dealing with a custom pull to refresh view, often the native UIRefreshControl is not ideal as it is not customizable. A common customization besides the pull to refresh, is to have a circular progress view with the logo of the app to show during the dragging. This version of the pull to refresh allows to preserve the contentInset on the scrollview.'
   s.homepage = 'https://github.com/beamly/BMYCircularProgressPullToRefresh'
   s.author   = { 'Alberto De Bortoli' => 'alberto@beamly.com', 'Stefan Dougan-Hyde' => 'stefan@beamly.com' }
-  s.source   = { :git => 'https://github.com/beamly/BMYCircularProgressPullToRefresh.git', :tag => '1.1.1' }
+  s.source   = { :git => 'https://github.com/beamly/BMYCircularProgressPullToRefresh.git', :tag => s.version }
   s.license      = { :type => 'New BSD License', :file => 'LICENSE.md' }
   s.source_files = ['BMYCircularProgressPullToRefresh/*.{h,m}','BMYCircularProgressPullToRefresh/**/*.{h,m}']
   s.requires_arc = true

--- a/BMYCircularProgressPullToRefresh/BMYPullToRefreshView/UIScrollView+BMYPullToRefresh.m
+++ b/BMYCircularProgressPullToRefresh/BMYPullToRefreshView/UIScrollView+BMYPullToRefresh.m
@@ -22,7 +22,6 @@ static char UIScrollViewPullToRefreshView;
 - (void)setPullToRefreshWithHeight:(CGFloat)height
                      actionHandler:(void (^)(BMYPullToRefreshView *pullToRefreshView))actionHandler {
     [self tearDownPullToRefresh];
-    [self.pullToRefreshView removeFromSuperview];
     BMYPullToRefreshView *view = [[BMYPullToRefreshView alloc] initWithHeight:height scrollView:self];
     [self addSubview:view];
     self.pullToRefreshView = view;
@@ -32,12 +31,9 @@ static char UIScrollViewPullToRefreshView;
 
 - (void)tearDownPullToRefresh {
     if (self.pullToRefreshView) {
-        self.pullToRefreshView.hidden = YES;
-        
-        [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
-        [self removeObserver:self.pullToRefreshView forKeyPath:@"contentSize"];
-        [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
-        [self removeObserver:self.pullToRefreshView forKeyPath:@"contentInset"];
+        [self _tearDownPullToRefresh];
+        [self.pullToRefreshView removeFromSuperview];
+        self.pullToRefreshView = nil;
     }
 }
 
@@ -55,9 +51,14 @@ static char UIScrollViewPullToRefreshView;
 
 #pragma mark - Private Methods
 
+- (void)_tearDownPullToRefresh {
+    [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
+    [self removeObserver:self.pullToRefreshView forKeyPath:@"contentSize"];
+    [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
+    [self removeObserver:self.pullToRefreshView forKeyPath:@"contentInset"];
+}
+
 - (void)_setupPullToRefresh {
-    self.pullToRefreshView.hidden = NO;
-    
     [self addObserver:self.pullToRefreshView forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:nil];
     [self addObserver:self.pullToRefreshView forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
     [self addObserver:self.pullToRefreshView forKeyPath:@"frame" options:NSKeyValueObservingOptionNew context:nil];


### PR DESCRIPTION
This causes a crash when calling -setup, -teardown and -setup subsequently.